### PR TITLE
add town selector

### DIFF
--- a/app/components/Map/index.js
+++ b/app/components/Map/index.js
@@ -7,8 +7,11 @@
 import React, { memo } from 'react';
 // import PropTypes from 'prop-types';
 // import styled from 'styled-components';
+import _ from 'lodash';
 
 import ReactMapGL from 'react-map-gl';
+import MapSelect from './mapSelect';
+import { townArray } from './townConstants';
 
 // import { FormattedMessage } from 'react-intl';
 // import messages from './messages';
@@ -26,7 +29,24 @@ class Map extends React.PureComponent {
         longitude: -79.9659,
         zoom: 8,
       },
+      selectedTown: 'Pittsburgh',
     };
+  }
+
+  handleSelection(event) {
+    const oldView = _.clone(this.state.viewport);
+    const place = event.target.value;
+    const { latitude, longitude } = _.find(townArray, { place });
+    const newView = _.assign({}, oldView, {
+      zoom: 12,
+      latitude,
+      longitude,
+    });
+
+    this.setState({
+      viewport: newView,
+      selectedTown: place,
+    });
   }
 
   render() {
@@ -36,6 +56,11 @@ class Map extends React.PureComponent {
           {...this.state.viewport}
           onViewportChange={viewport => this.setState({ viewport })}
           mapboxApiAccessToken="pk.eyJ1IjoiaHlwZXJmbHVpZCIsImEiOiJjaWpra3Q0MnIwMzRhdGZtNXAwMzRmNXhvIn0.tZzUmF9nGk2h28zx6PM13w"
+        />
+        <MapSelect
+          townArray={townArray}
+          selectedTown={this.state.selectedTown}
+          handleChange={e => this.handleSelection(e)}
         />
       </div>
     );

--- a/app/components/Map/mapSelect.js
+++ b/app/components/Map/mapSelect.js
@@ -1,0 +1,41 @@
+import React, { Component } from 'react';
+import Input from '@material-ui/core/Input';
+import InputLabel from '@material-ui/core/InputLabel';
+import MenuItem from '@material-ui/core/MenuItem';
+import FormHelperText from '@material-ui/core/FormHelperText';
+import FormControl from '@material-ui/core/FormControl';
+import Select from '@material-ui/core/Select';
+import PropTypes from 'prop-types';
+
+/* eslint-disable react/prefer-stateless-function */
+class MapSelect extends Component {
+  render() {
+    const towns = this.props.townArray;
+
+    return (
+      <div>
+        <FormControl>
+          <InputLabel htmlFor="town-selector">Town/Neighborhood</InputLabel>
+          <Select
+            value={this.props.selectedTown}
+            onChange={this.props.handleChange}
+            input={<Input name="townSelector" id="town-selector" />}
+          >
+            {towns.map(town => (
+              <MenuItem value={town.place}>{town.place}</MenuItem>
+            ))}
+          </Select>
+          <FormHelperText>Some important helper text</FormHelperText>
+        </FormControl>
+      </div>
+    );
+  }
+}
+
+MapSelect.propTypes = {
+  townArray: PropTypes.object.isRequired,
+  selectedTown: PropTypes.string.isRequired,
+  handleChange: PropTypes.func.isRequired,
+};
+
+export default MapSelect;

--- a/app/components/Map/townConstants.js
+++ b/app/components/Map/townConstants.js
@@ -1,0 +1,17 @@
+export const townArray = [
+  {
+    place: 'Pittsburgh',
+    latitude: 40.4406,
+    longitude: -79.9659,
+  },
+  {
+    place: 'Millvale',
+    latitude: 40.4801,
+    longitude: -79.9784,
+  },
+  {
+    place: 'Wexford',
+    latitude: 40.6266,
+    longitude: -80.055,
+  },
+];


### PR DESCRIPTION
adds a first draft of the town selector with 2 sample towns to start off.

map still defaults to wide view of Pittsburgh, but now if you select a town it zooms and shifts.

possible improvements include updating styling if desired, and adding more, better selected town centers.

possibility of adding a text and api based selector for getting towns not on the list is still valid as well